### PR TITLE
Corrección de ingreso manual de fechas en filtros

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@headlessui/react": "^2.2.0",
         "@tailwindcss/vite": "^4.0.0",
+        "date-fns": "^4.1.0",
         "frontend": "file:",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -2683,6 +2684,16 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@headlessui/react": "^2.2.0",
     "@tailwindcss/vite": "^4.0.0",
+    "date-fns": "^4.1.0",
     "frontend": "file:",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/Client/Store.ts
+++ b/src/Client/Store.ts
@@ -3,7 +3,8 @@ import { devtools } from "zustand/middleware";
 import { deleteData, getData, postData, putData } from "../shared/services/gym";
 import { Client, ClientDataForm } from "../shared/types";
 import { formatDateForParam } from "../shared/utils/format";
-import { stat } from "fs";
+import { format } from 'date-fns';
+import { isCompleteDate } from "../shared/utils/validation";
 
 type ClientStore = {
     clients: Client[];
@@ -125,6 +126,14 @@ export const useClientStore = create<ClientStore>()(
             }
             if (state.filterByBirthDateRangeMax !== null && state.filterByBirthDateRangeMin !== null) {
                 filters += `&filterByDateBirthStart=${formatDateForParam(state.filterByBirthDateRangeMin)}&filterByDateBirthEnd=${formatDateForParam(state.filterByBirthDateRangeMax)}`;
+            }
+            if (
+                isCompleteDate(state.filterByBirthDateRangeMax) &&
+                isCompleteDate(state.filterByBirthDateRangeMin)
+            ) {
+                const formattedDateMax = format(state.filterByBirthDateRangeMax!, 'yyyy-MM-dd');
+                const formattedDateMin = format(state.filterByBirthDateRangeMin!, 'yyyy-MM-dd');
+                filters += `&filterByDateRangeMax=${formattedDateMax}&filterByDateRangeMin=${formattedDateMin}`;
             }
             if(state.filterByClientType != 0){
                 filters += `&filterByTypeClient=${state.filterByClientType}`;

--- a/src/Expense/Store.ts
+++ b/src/Expense/Store.ts
@@ -2,7 +2,8 @@ import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { EconomicExpense, EconomicExpenseDataForm } from "../shared/types";
 import { deleteData, getData, postData, putData } from "../shared/services/gym";
-import { formatDateForParam } from "../shared/utils/format";
+import { format } from 'date-fns';
+import { isCompleteDate } from "../shared/utils/validation";
 
 type EconomicExpenseStore = {
     economicExpenses: EconomicExpense[];
@@ -89,8 +90,13 @@ export const useEconomicExpenseStore = create<EconomicExpenseStore>()(
             if (state.filterByAmountRangeMax !== 0 && state.filterByAmountRangeMin !== 0) {
                 filters += `&filterByAmountRangeMax=${state.filterByAmountRangeMax}&filterByAmountRangeMin=${state.filterByAmountRangeMin}`;
             }
-            if (state.filterByDateRangeMax !== null && state.filterByDateRangeMin !== null) {
-                filters += `&filterByDateRangeMax=${formatDateForParam(state.filterByDateRangeMax)}&filterByDateRangeMin=${formatDateForParam(state.filterByDateRangeMin)}`;
+            if (
+                isCompleteDate(state.filterByDateRangeMax) &&
+                isCompleteDate(state.filterByDateRangeMin)
+            ) {
+                const formattedDateMax = format(state.filterByDateRangeMax!, 'yyyy-MM-dd');
+                const formattedDateMin = format(state.filterByDateRangeMin!, 'yyyy-MM-dd');
+                filters += `&filterByDateRangeMax=${formattedDateMax}&filterByDateRangeMin=${formattedDateMin}`;
             }
             if (state.filterByMeanOfPayment != 0){
                 filters += `&filterByMeanOfPayment=${state.filterByMeanOfPayment}`

--- a/src/Income/Store.ts
+++ b/src/Income/Store.ts
@@ -2,7 +2,8 @@ import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { EconomicIncome, EconomicIncomeDataForm } from "../shared/types";
 import { deleteData, getData, postData, putData } from "../shared/services/gym";
-import { formatDateForParam } from "../shared/utils/format";
+import { format } from 'date-fns';
+import { isCompleteDate } from "../shared/utils/validation";
 
 type EconomicIncomeStore = {
     economicIncomes: EconomicIncome[];
@@ -89,8 +90,13 @@ export const useEconomicIncomeStore = create<EconomicIncomeStore>()(
             if (state.filterByAmountRangeMax !== 0 && state.filterByAmountRangeMin !== 0) {
                 filters += `&filterByAmountRangeMax=${state.filterByAmountRangeMax}&filterByAmountRangeMin=${state.filterByAmountRangeMin}`;
             }
-            if (state.filterByDateRangeMax !== null && state.filterByDateRangeMin !== null) {
-                filters += `&filterByDateRangeMax=${formatDateForParam(state.filterByDateRangeMax)}&filterByDateRangeMin=${formatDateForParam(state.filterByDateRangeMin)}`;
+            if (
+                isCompleteDate(state.filterByDateRangeMax) &&
+                isCompleteDate(state.filterByDateRangeMin)
+            ) {
+                const formattedDateMax = format(state.filterByDateRangeMax!, 'yyyy-MM-dd');
+                const formattedDateMin = format(state.filterByDateRangeMin!, 'yyyy-MM-dd');
+                filters += `&filterByDateRangeMax=${formattedDateMax}&filterByDateRangeMin=${formattedDateMin}`;
             }
             if (state.filterByMeanOfPayment != 0){
                 filters += `&filterByMeanOfPayment=${state.filterByMeanOfPayment}`

--- a/src/shared/utils/validation.ts
+++ b/src/shared/utils/validation.ts
@@ -1,0 +1,5 @@
+import { isValid } from 'date-fns';
+
+export function isCompleteDate(date: Date | null): boolean {
+    return date !== null && isValid(date);
+}


### PR DESCRIPTION
Se corrigió un bug que impedía escribir manualmente las fechas en los filtros de los módulos Clients, Expenses e Income. El problema ocurría porque el campo de fecha no aceptaba entrada manual y solo permitía selección desde el calendario. 