### PR TITLE
Recuperar Id Client Desde Medidas

### DIFF
--- a/src/Client/Page.tsx
+++ b/src/Client/Page.tsx
@@ -197,15 +197,10 @@ function ClientManagement() {
                                 >
                                     <MdModeEdit className="text-white" />
                                 </button>
-
-                                   
-
-                                                                
+                           
                                 <Link 
-                                    to={{
-                                        pathname: '/gestion/medidas',
-                                        state: { idClient: client.idClient }
-                                    }}
+                                    to="/gestion/medidas"
+                                    state={{ idClient: client.idClient }}
                                     className="p-2 bg-black rounded-sm hover:bg-gray-700 hover:cursor-pointer"
                                     title="Ver medidas"
                                 >

--- a/src/Measurement/Form.tsx
+++ b/src/Measurement/Form.tsx
@@ -4,7 +4,7 @@ import { MeasurementDataForm } from "../shared/types";
 import ErrorForm from "../shared/components/ErrorForm";
 import useMeasurementStore from "./Store";
 import { useEffect } from "react";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { formatDate } from "../shared/utils/format";
 import { getAuthUser, setAuthHeader, setAuthUser } from "../shared/utils/authentication";
 
@@ -12,7 +12,9 @@ const MAXDATE = new Date().toUTCString()
 
 function Form() {
     const navigate = useNavigate();
-    const { register, handleSubmit, setValue, formState: { errors }, reset, watch } = useForm<MeasurementDataForm>();
+    const location = useLocation(); 
+    const idClient = location.state?.idClient;
+    const { register, handleSubmit, setValue, formState: { errors }, reset } = useForm<MeasurementDataForm>();
     const { measurements, activeEditingId, fetchMeasurements, addMeasurement, updateMeasurement, closeModalForm } = useMeasurementStore();
     
     const submitForm = async (data: MeasurementDataForm) => {
@@ -108,6 +110,7 @@ function Form() {
             <input  
                 id="idClient" 
                 type="hidden"
+                value={idClient}
                 {...register('idClient')}
             />
             <input  

--- a/src/routes/PrivateRoutes.tsx
+++ b/src/routes/PrivateRoutes.tsx
@@ -9,6 +9,7 @@ import { useCommonDataStore } from "../shared/CommonDataStore";
 import AsideBar from "../shared/components/AsideBar";
 import ClientManagement from "../Client/Page";
 import NotificationTemplateManagement from "../TemplateNotification/Page";
+import MeasurementManagement from "../Measurement/Page";
 
 function PrivateRoutes () {
     // fetchear los datos comunes: roles, tipos de pago, etc. para solo hacerlo 1 vez
@@ -66,6 +67,12 @@ function PrivateRoutes () {
                 path="clientes" 
                 element={
                     <ClientManagement/>
+                }
+            />
+            <Route 
+                path="medidas" 
+                element={
+                    <MeasurementManagement/>
                 }
             />
             <Route 


### PR DESCRIPTION
Ahora se puede recuperar el idClient del cliente específico del cual fue presionado el botón que redirige a sus medidas corporales.

Cambios realizados:
Correción en la manera en la que se guardaba el idClient en el state de Location.
Usar useLocation desde el formulario para poder enviar el idClient en las consultas de Medidas al back.