### PR TITLE
Permitir actualización de usuario sin requerir contraseña

### DIFF
--- a/src/User/Form.tsx
+++ b/src/User/Form.tsx
@@ -30,10 +30,11 @@ function Form() {
         let action = '', result
         const loggedUser = getAuthUser()
         const reqUser = {
-            ...data, 
+            ...data,
+            password: data.password ? data.password : null, 
             paramLoggedIdUser: loggedUser?.idUser
-        }
-        
+        };
+    
         // si el editingId está en 0 significa que se está agregando 
         if(activeEditingId==0){
             result = await addUser(reqUser)
@@ -379,7 +380,7 @@ function Form() {
                     type="password" 
                     placeholder="Ingrese la contraseña" 
                     {...register('password', {
-                        required: 'La contraseña es obligatoria'
+                        required: activeEditingId === 0 ? 'La contraseña es obligatoria' : false
                     })}
                 />
 


### PR DESCRIPTION
Se modificó el formulario de usuario en el Frontend para que no requiera contraseña al actualizar
Se ajustó el Store para enviar null en la contraseña si el campo está vacío
Se actualizó el Stored Procedure para que solo modifique la contraseña si se envía un valor válido