### PR TITLE
Fix/precarga-clientes-rutina

### DIFF
--- a/src/Routine/Form.tsx
+++ b/src/Routine/Form.tsx
@@ -99,13 +99,15 @@ function Form() {
       setValue('idDifficultyRoutine', routineToEdit.difficultyRoutine?.idDifficultyRoutine || 0);
 
       if (routineToEdit.assignments?.length > 0) {
-        const clientOptions = routineToEdit.assignments.map(assignment => ({
-          value: assignment.idClient,
-          label: assignment.idClient.toString()
-        }));
+        const clientOptions = routineToEdit.assignments.map(assignment => {
+          const client = allClients.find(c => c.value === assignment.idClient);
+          return {
+            value: assignment.idClient,
+            label: client ? `${client.label}` : `Cliente ${assignment.idClient}`
+          };
+        });
         setSelectedClients(clientOptions);
       }
-
       if (routineToEdit.exercises?.length > 0 && exercise.length > 0) {
         const loadedExercises = routineToEdit.exercises.map(ex => {
           const exerciseData = exercise.find(e => e.idExercise === ex.idExercise);


### PR DESCRIPTION
Se implementó la precarga correcta de los clientes ya asignados cuando se edita una rutina existente. Ahora se muestra el nombre completo del cliente en lugar del ID.

Relacionado a:
- [FOR-989]: Modificar el formulario de actualizar para que recupere y precargue los clientes de...
- [FOR-990]: Confirmar la persistencia correcta de cambios tras edición

Cambios realizados:
- Modificado el mapeo de clientes asignados para mostrar nombre y apellido
- Asegurado que los datos de clientes estén cargados antes de la precarga
- Validación para no repetir clientes en la lista

Criterios de aceptación:
- [x] Al editar una rutina, se visualizan los clientes relacionados previamente
- [x] Los clientes se muestran con su nombre completo (nombre + apellido)
- [x] La selección persiste correctamente tras guardar los cambios

Casos de prueba:
1. Nombre: Precarga clientes existentes
   Pasos:
   - Editar una rutina con clientes asignados
   - Verificar que aparezcan precargados en el selector
   Resultado esperado: Nombres completos de clientes visibles en el campo

2. Nombre: Persistencia de cambios
   Pasos:
   - Editar una rutina existente
   - Modificar la selección de clientes
   - Guardar cambios
   - Reabrir la rutina editada
   Resultado esperado: Los cambios en clientes asignados se mantienen
![Precarga de rutinas](https://github.com/user-attachments/assets/0967a3ba-c371-4db3-a941-2e19b4cf5d5c)