### PR TITLE
Fix/validacion-fechas-manuales

### DIFF
--- a/src/Client/Store.ts
+++ b/src/Client/Store.ts
@@ -147,9 +147,6 @@ export const useClientStore = create<ClientStore>()(
             if(state.filterByBreathingIssues!=null){
                 filters += `&filterByBreathingIssues=${state.filterByBreathingIssues}`;
             }
-            if (state.filterByBirthDateRangeMax !== null && state.filterByBirthDateRangeMin !== null) {
-                filters += `&filterByDateBirthStart=${formatDateForParam(state.filterByBirthDateRangeMin)}&filterByDateBirthEnd=${formatDateForParam(state.filterByBirthDateRangeMax)}`;
-            }
             if (
                 isCompleteDate(state.filterByBirthDateRangeMax) &&
                 isCompleteDate(state.filterByBirthDateRangeMin)


### PR DESCRIPTION

Cambios realizados:
- Eliminado bloque de código duplicado para filtrado por fechas:
  ```typescript
  if (state.filterByBirthDateRangeMax !== null && state.filterByBirthDateRangeMin !== null) {
      filters += `&filterByDateBirthStart=${formatDateForParam(state.filterByBirthDateRangeMin)}&filterByDateBirthEnd=${formatDateForParam(state.filterByBirthDateRangeMax)}`;
  }

Casos de prueba:

Nombre: Filtrado por fechas válidas (manual)
Pasos:

Ingresar fechas manualmente 

Aplicar filtro
Esperado: Filtra clientes correctamente

