### PR TITLE
Feature/improve-measurements-pdf

### DIFF
--- a/src/Measurement/Page.tsx
+++ b/src/Measurement/Page.tsx
@@ -59,7 +59,7 @@ function MeasurementManagement() {
         }
     }, [idClient]);
 
-    const { handleDelete, handleOrderByChange, handleRestore, tableColumn, tableRows} = useMeasurement();
+    const { handleDelete, handleOrderByChange, handleRestore, tableColumn, tableRows, clientData} = useMeasurement();
     
     useEffect(() => {}, [measurements]);
     
@@ -121,7 +121,7 @@ function MeasurementManagement() {
                                                     modulo="Medidas corporales" 
                                                     closeModal={closeModalFileType} 
                                                     exportToPDF={() => exportToPDF('Medidas', tableColumn, tableRows)}
-                                                    exportToExcel={() => exportToExcel('Medidas', tableColumn, tableRows, true)}
+                                                    exportToExcel={() => exportToExcel('Medidas', tableColumn, tableRows, true, clientData)}
                                 />}
                             />
                         </div>

--- a/src/Measurement/useMeasurement.ts
+++ b/src/Measurement/useMeasurement.ts
@@ -125,31 +125,31 @@ export const useMeasurement = () => {
         name: `${measurements[0].client.person.name} ${measurements[0].client.person.firstLastName}`,
         age: calculateAge(measurements[0].client.person.birthday),
         height: measurements[0].height
-    } : null;
+    } : undefined;
     
     const tableColumn = [
         "Fecha",
-        "Peso",
+        "Peso (kg)",
         "% G.Corp", 
-        "M.M",
+        "M.M (kg)",
         "%G.Visc",
-        "Pecho",
-        "Espalda",
-        "Cintura",
-        "Cadera",
-        "Pierna D/I",
-        "Pantorrilla D/I",
-        "antebrazo",
-        "brazo"
+        "Pecho (cm)",
+        "Espalda (cm)",
+        "Cintura (cm)",
+        "Cadera (cm)",
+        "Pierna D/I (cm)",
+        "Pantorrilla D/I (cm)",
+        "Antebrazo D/I (cm)",
+        "Brazo D/I (cm)"
     ];
 
     const tableRows = measurements.map(measurement => {
         return [
-            formatDate(new Date(measurement.measurementDate)), // Fecha
-            measurement.weight, // Peso
-            measurement.bodyFatPercentage, // % Grasa Corporal
-            measurement.muscleMass, // Masa Muscular
-            measurement.visceralFatPercentage, // % Grasa Visceral
+            formatDate(new Date(measurement.measurementDate)),
+            `${measurement.weight.toFixed(1)}`, // 1 decimal para peso
+            `${measurement.bodyFatPercentage.toFixed(1)}%`, // % con 1 decimal
+            `${measurement.muscleMass.toFixed(1)}`,
+            `${measurement.visceralFatPercentage.toFixed(1)}%`,
             measurement.chestSize || "/", // Pecho
             measurement.backSize || "/", // Espalda
             measurement.waistSize || "/", // Cintura

--- a/src/shared/utils/pdf.ts
+++ b/src/shared/utils/pdf.ts
@@ -25,7 +25,7 @@ export const exportToPDF = (
   });
 
   const logo = "/Logo.webp";
-  doc.addImage(logo, 'WEBP', 13, 8, 35, 15);
+  doc.addImage(logo, "WEBP", 13, 8, 35, 15);
 
   doc.setFont("helvetica", "bold");
   doc.text(`Reporte de ${title}`, 105, 18, { align: "center" });
@@ -42,31 +42,9 @@ export const exportToPDF = (
 
   doc.line(13, 50, 195, 50);
 
-  autoTable(doc, {
-    theme: "striped",
-    head: [tableColumn],
-    body: tableRows,
-    startY: 55,
-    styles: {
-      font: "helvetica",
-      fontSize: 10,
-      textColor: [0, 0, 0],
-    },
-    headStyles: {
-      fillColor: [207, 173, 4],
-      textColor: [0, 0, 0],
-    },
-  });
+  let nextStartY = 55;
 
-  const finalY = (doc as any).lastAutoTable.finalY || 60;
-
-  // Solo si es reporte de medidas, se incluye la tabla de referencia
   if (title.toLowerCase() === "medidas") {
-    // Línea separadora antes de la tabla
-    doc.setLineWidth(0.1);
-    doc.setDrawColor(200, 200, 200);
-    doc.line(13, finalY + 5, 195, finalY + 5);
-
     const referenceHeaders = ["", "BAJO", "NORMAL", "ELEVADO", "MUY ELEVADO"];
     const referenceData = [
       ["IMC", "<18.5", "18.5 a 25", "25 a 30", "30 o +"],
@@ -82,13 +60,13 @@ export const exportToPDF = (
     ];
 
     autoTable(doc, {
-      startY: finalY + 10,
+      startY: nextStartY,
       head: [referenceHeaders],
       body: referenceData,
       theme: "grid",
       styles: {
-        fontSize: 8,
-        cellPadding: 2,
+        fontSize: 7,
+        cellPadding: 0.8,
         halign: "center",
         valign: "middle",
       },
@@ -101,7 +79,28 @@ export const exportToPDF = (
         0: { fillColor: [242, 242, 242], fontStyle: "bold" },
       },
     });
+
+    nextStartY = (doc as any).lastAutoTable.finalY + 6;
+    doc.line(13, nextStartY - 3, 195, nextStartY - 3);
   }
+
+  autoTable(doc, {
+    startY: nextStartY,
+    head: [tableColumn],
+    body: tableRows,
+    theme: "striped",
+    styles: {
+      font: "helvetica",
+      fontSize: 9,
+      cellPadding: 1.5,
+      textColor: [0, 0, 0],
+    },
+    headStyles: {
+      fillColor: [207, 173, 4],
+      textColor: [0, 0, 0],
+      fontSize: 9,
+    },
+  });
 
   doc.save(`Reporte de ${title} - ${formattedCurrentDate}.pdf`);
 };


### PR DESCRIPTION
Se optimizó la generación de PDF para reportes de medidas, mejorando la legibilidad y organización de los datos

Cambios realizados:
Se movió la tabla de referencia antes de los datos de medidas.
Se redujo el tamaño de fuente y el padding para mejor compactación.
Se centró el texto en todas las celdas para mejor legibilidad.

Criterios de aceptación
✔ La tabla de referencia aparece al inicio del PDF.
✔ El texto de las medidas está centrado y legible.
✔ Los valores numéricos se muestran claramente diferenciados.

Casos de prueba
1. Generación de PDF de medidas
Pasos:

Ejecutar generación de reporte de medidas

Abrir el PDF resultante.
Esperado:

Tabla de referencia visible al inicio.

Datos de medidas legibles y bien organizados.

![medidas](https://github.com/user-attachments/assets/bea6cbea-b78a-47a1-adb4-f5160f3db6bc)
.