### PR TITLE
[16/05/2025 17:03h] Actualizacion mensaje de error en el forgotPassword

### DIFF
--- a/src/Client/Form/useMultiStepForm.ts
+++ b/src/Client/Form/useMultiStepForm.ts
@@ -141,7 +141,18 @@ export const useMultiStepForm = () => {
       setAuthHeader(null);
       setAuthUser(null);
       navigate('/login');
-    }
+    } else {
+    await Swal.fire({
+      title: 'Error al guardar',
+      text: result.error || 'Ocurrió un error inesperado al guardar el cliente.',
+      icon: 'error',
+      confirmButtonText: 'OK',
+      confirmButtonColor: '#CFAD04',
+      timer: 3000,
+      timerProgressBar: true,
+      width: 500
+    });
+  }
   };
 
   const handleClose = () => {

--- a/src/Login/ForgotPasswordForm.tsx
+++ b/src/Login/ForgotPasswordForm.tsx
@@ -10,11 +10,27 @@ function ForgotPasswordForm () {
 
     const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
-    
+
         const form = e.currentTarget;
         const emailInput = form.elements[0] as HTMLInputElement;
         const email = emailInput.value;
-    
+
+        // Validación de correo
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailRegex.test(email)) {
+            await Swal.fire({
+                title: 'Correo inválido',
+                text: 'Por favor, ingresá un correo electrónico válido',
+                icon: 'warning',
+                confirmButtonText: 'OK',
+                timer: 3000,
+                timerProgressBar: true,
+                width: 300,
+                confirmButtonColor: '#CFAD04'
+            });
+            return;
+        }
+
         const captchaValue = recaptcha.current?.getValue();
         if (!captchaValue) {
             await Swal.fire({
@@ -29,11 +45,11 @@ function ForgotPasswordForm () {
             });
             return;
         }
-    
+
         try {
             const res = await postData(`${import.meta.env.VITE_URL_API}recoveryPassword?email=${encodeURIComponent(email)}`, {});
             console.log(res)
-    
+
             if (res.ok) {
                 await Swal.fire({
                     title: 'Correo enviado',
@@ -51,7 +67,7 @@ function ForgotPasswordForm () {
         } catch (error) {
             await Swal.fire({
                 title: 'Error',
-                text: 'Ocurrió un error al procesar su solicitud',
+                text: 'El correo usado no está registrado',
                 icon: 'error',
                 confirmButtonText: 'OK',
                 timer: 3000,


### PR DESCRIPTION
Criterios de aceptación
Mensajes claros y detallados desde backend

Nombre Caso de prueba
Validar especificidad en alertas

Pasos
Provocar error (ej. correo duplicado)

Resultado esperado
Mensaje específico y claro del error