### PR TITLE
Feature/ModificarUnicamenteSuPropioNombreUsuario

### DIFF
--- a/src/User/Form/StepAccountInfo.tsx
+++ b/src/User/Form/StepAccountInfo.tsx
@@ -72,19 +72,29 @@ export const AccountInfoStep = ({ activeEditingId, roles }: { activeEditingId: n
         <label htmlFor="username" className="text-sm uppercase font-bold">
           Nombre de usuario 
         </label>
+        
+        {activeEditingId !== 0 && !isSelfEditing && (
+          <p className="text-sm text-gray-500 mb-1 italic">
+            Nota: Solo puedes modificar tu propio nombre de usuario cuando editas tu perfil.
+          </p>
+        )}
+        
         <input  
           id="username"
-          className="w-full p-3 border border-gray-100"  
+          className={`w-full p-3 border ${activeEditingId !== 0 && !isSelfEditing ? 'bg-gray-100 cursor-not-allowed' : 'border-gray-100'}`}  
           type="text" 
-          placeholder="Ingrese el nombre de usuario" 
+          placeholder={activeEditingId !== 0 && !isSelfEditing ? "No editable" : "Ingrese el nombre de usuario"} 
           {...register('username', {
             required: 'El nombre de usuario es obligatorio',
             maxLength: {
               value: MAXLENGTH_USERNAME,
               message: `Debe ingresar un nombre de usuario de máximo ${MAXLENGTH_USERNAME} carácteres`
-            }
+            },
+            disabled: activeEditingId !== 0 && !isSelfEditing
           })}
+          disabled={activeEditingId !== 0 && !isSelfEditing}
         />
+        
         {errors.username && <ErrorForm>{errors.username.message?.toString()}</ErrorForm>}
       </div>
 

--- a/src/User/Form/useMultiStepForm.ts
+++ b/src/User/Form/useMultiStepForm.ts
@@ -73,6 +73,7 @@ export const useMultiStepForm = () => {
     const isSelfEditing = loggedUser?.idUser === data.idUser;
     const reqUser: UserDataForm & { paramLoggedIdUser?: number } = {
       ...data,
+      username: isSelfEditing ? data.username : defaultValues.username,
       password: isSelfEditing ? data.password : '', 
       paramLoggedIdUser: loggedUser?.idUser
     };


### PR DESCRIPTION
Criterios de aceptación
El campo de nombre de usuario debe estar deshabilitado para edición


Nombre Caso de prueba
Validar restricción de edición del username

Pasos
Ir a edición de usuario 
Intentar cambiar username

Resultado esperado
Campo username deshabilitado