### PR TITLE
 Refactor / Renombrar typeClient a clientType en frontend

### DIFF
--- a/src/ActivityType/DataInfo.tsx
+++ b/src/ActivityType/DataInfo.tsx
@@ -3,7 +3,7 @@ import { useCommonDataStore } from "../shared/CommonDataStore";
 
 function DataInfo() {
     const { activityTypes, activeEditingId } = useActivityTypeStore();
-    const { typesClient } = useCommonDataStore();
+    const { clientTypes } = useCommonDataStore();
     
     if (!activeEditingId) return <></>;
 
@@ -11,7 +11,7 @@ function DataInfo() {
     if (!activityType) return <></>;
 
     const getClientTypeName = (id: number) => {
-        const clientType = typesClient.find(type => type.idTypeClient === id);
+        const clientType = clientTypes.find(type => type.idClientType === id);
         return clientType ? clientType.name : `Tipo ${id}`;
     };
 

--- a/src/Client/DataInfo.tsx
+++ b/src/Client/DataInfo.tsx
@@ -202,27 +202,7 @@ function DataInfo() {
 
                 <div className="flex flex-col gap-2 text-lg">
                     <p><strong>NOMBRE</strong></p>
-                    <p>{client.typeClient.name}</p>
-                </div>
-
-                <div className="flex flex-col gap-2 text-lg">
-                    <p><strong>PRECIO POR DÍA</strong></p>
-                    <p>{formatAmountToCRC(client.typeClient.dailyCharge)}</p>
-                </div>
-
-                <div className="flex flex-col gap-2 text-lg">
-                    <p><strong>PRECIO POR SEMANA</strong></p>
-                    <p>{formatAmountToCRC(client.typeClient.weeklyCharge)}</p>
-                </div>
-
-                <div className="flex flex-col gap-2 text-lg">
-                    <p><strong>PRECIO POR QUINCENA</strong></p>
-                    <p>{formatAmountToCRC(client.typeClient.biweeklyCharge)}</p>
-                </div>
-
-                <div className="flex flex-col gap-2 text-lg">
-                    <p><strong>PRECIO POR MES</strong></p>
-                    <p>{formatAmountToCRC(client.typeClient.monthlyCharge)}</p>
+                    <p>{client.clientType.name}</p>
                 </div>
 
                 <div className="flex flex-col gap-2 text-lg">

--- a/src/Client/Filter.tsx
+++ b/src/Client/Filter.tsx
@@ -66,7 +66,7 @@ export function FilterSelect() {
     const filteredBirthDateRangeStyles = (filterByBirthDateRangeMin !== null && filterByBirthDateRangeMax !== null)  && ' px-0.5 border-yellow text-yellow';
     const filteredClientTypeSelectStyles = filterByClientType !== -1 && ' px-0.5 border-yellow text-yellow';
 
-    const { typesClient } = useCommonDataStore();
+    const { clientTypes } = useCommonDataStore();
     const filters = [
         { label: "Diabetes", state: filterByDiabetes, changeState: changeFilterByDiabetes },
         { label: "Hipertensión", state: filterByHypertension, changeState: changeFilterByHypertension },
@@ -111,17 +111,17 @@ export function FilterSelect() {
             </div>
 
             <div className="flex items-center gap-4">
-                <label htmlFor="idTypeClient" className="w-20">Tipo de Cliente</label>
+                <label htmlFor="idClientType" className="w-20">Tipo de Cliente</label>
                 <select
-                    id="idTypeClient"
+                    id="idClientType"
                     className={"border rounded-md p-2 w-78 text-center" + filteredClientTypeSelectStyles}
                     value={filterByClientType}
                     onChange={(e) => changeFilterByClientType(+e.target.value)}
                 >
                     <option value={-1}>Todos</option>
 
-                    {typesClient.map((type)=> (
-                        <option key={type.idTypeClient} value={type.idTypeClient}>
+                    {clientTypes.map((type)=> (
+                        <option key={type.idClientType} value={type.idClientType}>
                             {type.name}
                         </option>
                     ))}

--- a/src/Client/Form/MultiStepForm.tsx
+++ b/src/Client/Form/MultiStepForm.tsx
@@ -25,7 +25,7 @@ const MultiStepForm = () => {
       case 1:
         return <StepContract />;
       case 2:
-        return <StepClientInfo genders={genders} typesClient={clientTypes} />;
+        return <StepClientInfo genders={genders} clientTypes={clientTypes} />;
       case 3:
         return <StepContactInfo />;
       case 4:

--- a/src/Client/Form/StepContract.tsx
+++ b/src/Client/Form/StepContract.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import SignatureCanvas from 'react-signature-canvas';
 import ErrorForm from '../../shared/components/ErrorForm';
 
 const CONTRACT_TEXT = `
 Con la firma del presente contrato, se aceptan los términos y condiciones estipulados a continuación:
--Force Gym es un Gimnasio Tradicional, en el cual pueden realizarse ejercicios con pesas, discos, barras y máquinas. Por tanto; no están permitidos “El powerlifting” o cualquier otro que conlleve levantar la mayor cantidad de peso posible y altere el orden del establecimiento. 
+-Force Gym es un Gimnasio Tradicional, en el cual pueden realizarse ejercicios con pesas, discos, barras y máquinas. Por tanto; no están permitidos "El powerlifting" o cualquier otro que conlleve levantar la mayor cantidad de peso posible y altere el orden del establecimiento. 
 -Force Gym no será responsable de los problemas de salud que pueda sufrir a consecuencia del uso de sus instalaciones. Con la suscripción del presente contrato se declara que está en buenas condiciones para la realización de ejercicio físico. Será responsabilidad del usuario realizarse periódicamente las debidas evaluaciones médicas mediante las cuales se certifique que su estado de salud es adecuado para la práctica de ejercicio físico.
 -El usuario deberá seguir las indicaciones de los instructores durante la clase o sesión de entrenamiento, Force Gym quedará exonerado de responsabilidad, en caso de producirse un accidente por la indebida manipulación de los equipos y elementos que se encuentren dentro de las instalaciones.
 -Force Gym no se hace responsable de los objetos personales que puedan extraviarse dentro de las instalaciones.
@@ -18,46 +18,27 @@ Con la firma del presente contrato, se aceptan los términos y condiciones estip
 -El incumplimiento de estos términos y condiciones podrá dar lugar, según la gravedad, a la expulsión de las instalaciones.
 `;
 
-
 export const StepContract = () => {
   const { 
     setValue, 
-    watch, 
-    formState: { errors }, 
-    trigger,
-    register 
+    formState: { errors } 
   } = useFormContext();
   
   const sigCanvasRef = useRef<SignatureCanvas>(null);
-  const signature = watch('signatureImage');
-
-  register('signatureImage', {
-    required: 'Debe proporcionar su firma para continuar',
-    validate: {
-      hasSignature: () => 
-        !sigCanvasRef.current?.isEmpty() || 'La firma es requerida'
-    }
-  });
-
-  useEffect(() => {
-    trigger('signatureImage');
-  }, [signature, trigger]);
 
   const handleClear = () => {
     sigCanvasRef.current?.clear();
-    setValue('signatureImage', '', { shouldValidate: true });
+    setValue('signatureImage', '');
   };
 
   const handleSignatureEnd = () => {
-    if (!sigCanvasRef.current?.isEmpty()) {
-      if (sigCanvasRef.current) {
-        const signatureData = sigCanvasRef.current
-          .getTrimmedCanvas()
-          .toDataURL('image/png');
-        setValue('signatureImage', signatureData, { shouldValidate: true });
-      }
+    if (sigCanvasRef.current && !sigCanvasRef.current.isEmpty()) {
+      const signatureData = sigCanvasRef.current
+        .getTrimmedCanvas()
+        .toDataURL('image/png');
+      setValue('signatureImage', signatureData);
     } else {
-      setValue('signatureImage', '', { shouldValidate: true });
+      setValue('signatureImage', '');
     }
   };
 

--- a/src/Client/Form/StepPersonalInfo.tsx
+++ b/src/Client/Form/StepPersonalInfo.tsx
@@ -10,32 +10,32 @@ const MAXDATE_BIRTHDAY = new Date().toUTCString();
 const MINLENGTH_IDENTIFICATIONUMBER = 7;
 const MINLENGTH_NAME = 2;
 
-export const StepClientInfo = ({ genders, typesClient }: { genders: any[], typesClient: any[] }) => {
+export const StepClientInfo = ({ genders, clientTypes }: { genders: any[], clientTypes: any[] }) => {
   const { register, formState: { errors } } = useFormContext();
   
   return (
     <div className="space-y-5">
       <div>
-        <label htmlFor="idTypeClient" className="text-sm uppercase font-bold">
+        <label htmlFor="idClientType" className="text-sm uppercase font-bold">
           Tipo de Cliente
         </label>
         <select
-          id="idTypeClient"
+          id="idClientType"
           className="w-full p-3 border border-gray-100" 
           defaultValue=""
-          {...register("idTypeClient", {
+          {...register("idClientType", {
             required: "El tipo de cliente es obligatorio",
             validate: value => value !== 0 || 'Debe seleccionar un tipo de cliente'
           })}  
         >
           <option value={0}>Seleccione un tipo de cliente</option>
-          {typesClient.map((type) => (
-            <option key={type.idTypeClient} value={type.idTypeClient}>
+          {clientTypes.map((type) => (
+            <option key={type.idClientType} value={type.idClientType}>
               {type.name}
             </option>
           ))}
         </select>
-        {errors.idTypeClient && <ErrorForm>{errors.idTypeClient.message?.toString()}</ErrorForm>}
+        {errors.idClientType && <ErrorForm>{errors.idClientType.message?.toString()}</ErrorForm>}
       </div>
 
       <div>

--- a/src/Client/Form/useMultiStepForm.ts
+++ b/src/Client/Form/useMultiStepForm.ts
@@ -17,7 +17,7 @@ export const useMultiStepForm = () => {
   const getDefaultValues = (): ClientDataForm => ({
     idClient: 0,
     idUser: 0,
-    idTypeClient: 0,
+    idClientType: 0,
     registrationDate: new Date(),
     expirationMembershipDate: new Date(),
     phoneNumberContactEmergency: '',
@@ -62,7 +62,7 @@ export const useMultiStepForm = () => {
     return {
       idClient: activeClient.idClient,
       idUser: activeClient.user.idUser,
-      idTypeClient: activeClient.typeClient.idTypeClient,
+      idClientType: activeClient.clientType.idClientType,
       registrationDate: formatToYYYYMMDD(activeClient.registrationDate),
       expirationMembershipDate: activeClient.expirationMembershipDate,
       phoneNumberContactEmergency: activeClient.phoneNumberContactEmergency,
@@ -163,7 +163,7 @@ export const useMultiStepForm = () => {
   };
 
   type FormField =
-    | "idClient" | "idUser" | "idTypeClient" | "registrationDate"
+    | "idClient" | "idUser" | "idClientType" | "registrationDate"
     | "phoneNumberContactEmergency" | "nameEmergencyContact" | "signatureImage" | "isDeleted"
     | "idHealthQuestionnaire" | "diabetes" | "hypertension" | "muscleInjuries"
     | "boneJointIssues" | "balanceLoss" | "cardiovascularDisease" | "breathingIssues"
@@ -177,7 +177,7 @@ export const useMultiStepForm = () => {
 
   const inputsByStep: StepFields[] = [
     { step: 1, fields: ['signatureImage']},
-    { step: 2, fields: ['idTypeClient', 'identificationNumber', 'name', 'firstLastName', 'secondLastName', 'birthday', 'idGender'] },
+    { step: 2, fields: ['idClientType', 'identificationNumber', 'name', 'firstLastName', 'secondLastName', 'birthday', 'idGender'] },
     { step: 3, fields: ['phoneNumber', 'email', 'registrationDate', 'nameEmergencyContact', 'phoneNumberContactEmergency'] },
     { step: 4, fields: ['diabetes', 'hypertension', 'muscleInjuries', 'boneJointIssues', 'balanceLoss', 'cardiovascularDisease', 'breathingIssues'] }
   ];

--- a/src/Client/Page.tsx
+++ b/src/Client/Page.tsx
@@ -182,7 +182,7 @@ function ClientManagement() {
                                 <td className="py-2">{client.person.identificationNumber}</td>
                                 <td className="py-2">{client.person.name + ' ' + client.person.firstLastName + ' ' + client.person.secondLastName}</td> 
                                 <td className="py-2">{formatDate(new Date(client.registrationDate))}</td>
-                                <td className="py-2">{client.typeClient.name}</td>
+                                <td className="py-2">{client.clientType.name}</td>
                                 {filterByStatus && (
                                 <td>
                                     {client.isDeleted ? (

--- a/src/Client/Store.ts
+++ b/src/Client/Store.ts
@@ -156,7 +156,7 @@ export const useClientStore = create<ClientStore>()(
                 filters += `&filterByDateRangeMax=${formattedDateMax}&filterByDateRangeMin=${formattedDateMin}`;
             }
             if(state.filterByClientType != 0){
-                filters += `&filterByTypeClient=${state.filterByClientType}`;
+                filters += `&filterByClientType=${state.filterByClientType}`;
             }
 
             const result = await getData(

--- a/src/Client/useClient.ts
+++ b/src/Client/useClient.ts
@@ -116,7 +116,7 @@ export const useClient = () => {
         client.person.identificationNumber,
         `${client.person.name} ${client.person.firstLastName} ${client.person.secondLastName}`,
         formatDate(new Date(client.registrationDate)),
-        client.typeClient.name
+        client.clientType.name
     ]);
 
     return {

--- a/src/Income/DataInfo.tsx
+++ b/src/Income/DataInfo.tsx
@@ -50,7 +50,7 @@ function DataInfo() {
 
                 <div className="flex flex-col gap-2 text-lg">
                     <p><strong>TIPO </strong></p>
-                    <p>{economicIncome.client.typeClient.name}</p>
+                    <p>{economicIncome.client.clientType.name}</p>
                 </div>
 
                 <div className="flex flex-col gap-2 text-lg">

--- a/src/Income/Filter.tsx
+++ b/src/Income/Filter.tsx
@@ -43,7 +43,7 @@ export function FilterSelect() {
     const filteredAmountRangeStyles = (filterByAmountRangeMin!=0 && filterByAmountRangeMax!=0)  && ' px-0.5 border-yellow text-yellow'
     const filteredDateRangeStyles = (filterByDateRangeMin !=null && filterByDateRangeMax!=null)  && ' px-0.5 border-yellow text-yellow'
     const filteredClientTypeSelectStyles = filterByClientType !== -1 && ' px-0.5 border-yellow text-yellow';
-    const { meansOfPayment, typesClient } = useCommonDataStore()
+    const { meansOfPayment, clientTypes } = useCommonDataStore()
 
     return (
         <div className="flex flex-col gap-4">
@@ -117,17 +117,17 @@ export function FilterSelect() {
             </div>
 
             <div className="flex items-center gap-4">
-                <label htmlFor="idTypeClient" className="w-20">Tipo de Cliente</label>
+                <label htmlFor="idClientType" className="w-20">Tipo de Cliente</label>
                 <select
-                    id="idTypeClient"
+                    id="idClientType"
                     className={"border rounded-md p-2 w-78 text-center" + filteredClientTypeSelectStyles}
                     value={filterByClientType}
                     onChange={(e) => changeFilterByClientType(+e.target.value)}
                 >
                     <option value={-1}>Todos</option>
 
-                    {typesClient.map((type)=> (
-                        <option key={type.idTypeClient} value={type.idTypeClient}>
+                    {clientTypes.map((type)=> (
+                        <option key={type.idClientType} value={type.idClientType}>
                             {type.name}
                         </option>
                     ))}

--- a/src/Income/Store.ts
+++ b/src/Income/Store.ts
@@ -121,7 +121,7 @@ export const useEconomicIncomeStore = create<EconomicIncomeStore>()(
                 filters += `&filterByMeanOfPayment=${state.filterByMeanOfPayment}`
             }
             if (state.filterByClientType != -1){
-                filters += `&filterByTypeClient=${state.filterByClientType}`
+                filters += `&filterByClientType=${state.filterByClientType}`
             }
 
             const result = await getData(

--- a/src/shared/CommonDataStore.ts
+++ b/src/shared/CommonDataStore.ts
@@ -1,13 +1,12 @@
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
-import { ActivityType, TypeClient, MeanOfPayment, Role, Gender, ClientOptions, Category, NotificationType, ExerciseCategory, ExerciseDifficulty, Exercise, DifficultyRoutine, ClientType} from "./types";
+import { ActivityType, MeanOfPayment, Role, Gender, ClientOptions, Category, NotificationType, ExerciseCategory, ExerciseDifficulty, Exercise, DifficultyRoutine, ClientType} from "./types";
 import { getData } from "./services/gym";
 
 type CommonDataStore = {
     roles: Role[]
     activityTypes: ActivityType[]
     meansOfPayment: MeanOfPayment[]
-    typesClient: TypeClient[]
     clientTypes: ClientType[]
     genders: Gender[]
     allClients: ClientOptions[]
@@ -20,7 +19,6 @@ type CommonDataStore = {
     fetchRoles: () => Promise<any>
     fetchMeansOfPayment: () => Promise<any>
     fetchActivityTypes: () => Promise<any>
-    fetchTypesClient: () => Promise<any>
     fetchClientTypes: () => Promise<any>
     fetchGenders: () => Promise<any>
     fetchAllClients: () => Promise<any>
@@ -37,7 +35,7 @@ export const useCommonDataStore = create<CommonDataStore>()(
         roles: [],
         meansOfPayment: [],
         activityTypes: [],
-        typesClient: [],
+        clientTypes: [],
         genders: [],
         allClients: [],
         categories: [],
@@ -62,12 +60,6 @@ export const useCommonDataStore = create<CommonDataStore>()(
         fetchActivityTypes: async () => {
             const result = await getData(`${import.meta.env.VITE_URL_API}activityType/listFees`)
             set(() => ({ activityTypes: result.data }))
-            return result
-        },
-
-        fetchTypesClient: async () => {
-            const result = await getData(`${import.meta.env.VITE_URL_API}typeClient/list`)
-            set(() => ({ typesClient: result.data.typesClient }))
             return result
         },
         fetchClientTypes: async () => {

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -175,7 +175,7 @@ export type Client = {
     idClient: number
     user: User
     person: Person
-    typeClient: TypeClient
+    clientType: ClientType
     healthQuestionnaire: HealthQuestionnaire
     registrationDate: Date
     expirationMembershipDate: string | Date
@@ -214,7 +214,7 @@ export type MeasurementDataForm = Omit<Measurement, 'client'> & {
     idClient: number
 }
 
-export type ClientDataForm = Omit<Client, 'user' | 'person' | 'typeClient' | 'healthQuestionnaire'| 'registrationDate'> & HealthQuestionnaire & Omit<Person, 'gender'> & Pick<User, 'idUser'>  & Pick<TypeClient, 'idTypeClient'> & {
+export type ClientDataForm = Omit<Client, 'user' | 'person' | 'typeClient' | 'healthQuestionnaire'| 'registrationDate'> & HealthQuestionnaire & Omit<Person, 'gender'> & Pick<User, 'idUser'>  & Pick<ClientType, 'idClientType'> & {
     idGender: number
     registrationDate: string | Date
 }

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -55,7 +55,7 @@ export type ClientType = {
     isDeleted: number
 }
 export type TypeClient = {
-    idTypeClient: number
+    idClientType: number
     name: string
     dailyCharge: number
     weeklyCharge: number
@@ -214,7 +214,7 @@ export type MeasurementDataForm = Omit<Measurement, 'client'> & {
     idClient: number
 }
 
-export type ClientDataForm = Omit<Client, 'user' | 'person' | 'typeClient' | 'healthQuestionnaire'| 'registrationDate'> & HealthQuestionnaire & Omit<Person, 'gender'> & Pick<User, 'idUser'>  & Pick<ClientType, 'idClientType'> & {
+export type ClientDataForm = Omit<Client, 'user' | 'person' | 'clientType' | 'healthQuestionnaire'| 'registrationDate'> & HealthQuestionnaire & Omit<Person, 'gender'> & Pick<User, 'idUser'>  & Pick<ClientType, 'idClientType'> & {
     idGender: number
     registrationDate: string | Date
 }

--- a/src/shared/types/mapper.ts
+++ b/src/shared/types/mapper.ts
@@ -102,7 +102,8 @@ export function mapClientToDataForm(client: Client): ClientDataForm {
     return {
         idClient: client.idClient,
         idUser: client.user.idUser,
-        idTypeClient: client.typeClient.idTypeClient,
+        idClientType: client.clientType.idClientType,
+        clientType: client.clientType, // Add the missing clientType property
         registrationDate: client.registrationDate,
         expirationMembershipDate: client.expirationMembershipDate,
         phoneNumberContactEmergency: client.phoneNumberContactEmergency,

--- a/src/shared/types/mapper.ts
+++ b/src/shared/types/mapper.ts
@@ -103,7 +103,6 @@ export function mapClientToDataForm(client: Client): ClientDataForm {
         idClient: client.idClient,
         idUser: client.user.idUser,
         idClientType: client.clientType.idClientType,
-        clientType: client.clientType, // Add the missing clientType property
         registrationDate: client.registrationDate,
         expirationMembershipDate: client.expirationMembershipDate,
         phoneNumberContactEmergency: client.phoneNumberContactEmergency,


### PR DESCRIPTION
Se realizó el cambio de nombre del atributo typeClient por clientType en todo el código del frontend para mantener consistencia con el backend y la base de datos.

Cambios realizados:

Actualización en formularios,validaciones, listas y fetch.

Cambio en interfaces/DTO relacionados al cliente.

Ajuste en los endpoints y consumo de servicios.

Criterios de aceptación:
✓ Todos los formularios relacionados a clientes funcionan correctamente.
✓ No se rompe la comunicación con backend.
✓ El nuevo nombre es coherente en todo el código.

Casos de prueba:

Nombre: Crear nuevo cliente
Pasos:

Ir a módulo de clientes

Completar formulario con tipo de cliente

Guardar
Esperado: Cliente guardado correctamente con clientType